### PR TITLE
Add the rubyracer to drop nodejs dep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,8 @@ gem "minima"
 # group :jekyll_plugins do
 #   gem "jekyll-github-metadata", "~> 1.0"
 # end
+
+# The CoffeeScript gem depends on execjs which requires a JavaScript runtime.
+# This does the trick without nodejs.
+gem "therubyracer"
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       jekyll (>= 3.0)
     json (1.8.3)
     kramdown (1.11.1)
+    libv8 (3.16.14.15)
     liquid (3.0.6)
     listen (3.0.6)
       rb-fsevent (>= 0.9.3)
@@ -112,6 +113,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    ref (2.0.0)
     rouge (1.11.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
@@ -120,6 +122,9 @@ GEM
       faraday (~> 0.8, < 0.10)
     terminal-table (1.7.3)
       unicode-display_width (~> 1.1.1)
+    therubyracer (0.12.2)
+      libv8 (~> 3.16.14.0)
+      ref
     thread_safe (0.3.5)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
@@ -133,9 +138,4 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   minima
-
-RUBY VERSION
-   ruby 2.3.1p112
-
-BUNDLED WITH
-   1.13.2
+  therubyracer


### PR DESCRIPTION
add therubyracer since we dont necessarily have nodejs as our javascript runtime. JS runtime is required by coffeescript that is required by the github pages gem bundle.